### PR TITLE
Fix the url in SimpleButton.vue

### DIFF
--- a/src/components/reusable/SimpleButton.vue
+++ b/src/components/reusable/SimpleButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <a class="btn mr-md-2" href="{{ url }}" role="button" target="_blank"
+  <a class="btn mr-md-2" :href="url" role="button" target="_blank"
     ><font-awesome-icon :icon="icon.split(' ')" class="me-2" /><slot></slot
   ></a>
 </template>


### PR DESCRIPTION
Currently, the URL is broken on the main page.
On clicking the HireMe button it redirects to 'https://rusetskii.dev/%7B%7B%20url%20%7D%7D' which returns a 404 page.